### PR TITLE
test: add solvency fraud-proof coverage

### DIFF
--- a/FRAUD_PROOF.md
+++ b/FRAUD_PROOF.md
@@ -1,0 +1,52 @@
+# Fraud proof for Challenge #1
+
+This PR adds a deterministic BitVM 2 fraud-proof artifact for the published
+`fixtures/fraudulent_trace.json` scenario and documents exactly why the
+operator's claimed `stack_after = ["true"]` is invalid.
+
+## Taproot script-path witness
+
+For the published predicate `01645a9502e8035f95a269`, the script-path witness
+stack that replays the operator's claimed inputs is:
+
+- `0x64` (pool balance = 100)
+- `0xe803` (max payout = 1000, minimally encoded little-endian)
+
+As a minimal push-only witness vector:
+
+```text
+[0x64, 0xe803]
+```
+
+When these witness elements are placed on the initial Bitcoin Script stack and
+executed against the committed predicate bytes, evaluation reaches
+`OP_VERIFY (0x69)` with `false` on top of the stack, so the script aborts.
+
+## Stack walk
+
+Committed predicate bytes:
+
+```text
+01 64 5a 95 02 e8 03 5f 95 a2 69
+```
+
+Decoded:
+
+```text
+PUSH(100) OP_10 OP_MUL PUSH(1000) OP_15 OP_MUL OP_GREATERTHANOREQUAL OP_VERIFY
+```
+
+Execution:
+
+1. `PUSH(100)` → stack: `[100]`
+2. `OP_10` → stack: `[100, 10]`
+3. `OP_MUL` → stack: `[1000]`
+4. `PUSH(1000)` → stack: `[1000, 1000]`
+5. `OP_15` → stack: `[1000, 1000, 15]`
+6. `OP_MUL` → stack: `[1000, 15000]`
+7. `OP_GREATERTHANOREQUAL` → evaluates `1000 >= 15000` = `false`
+8. `OP_VERIFY` (`0x69`) aborts because the top stack item is `false`
+
+The bisection terminates at this single step because the trace only contains
+one disputed transition, and the committed L1 predicate for that transition is
+self-contained and deterministic.

--- a/tests/fraud_proof.rs
+++ b/tests/fraud_proof.rs
@@ -1,0 +1,43 @@
+use actuarial_vm::taproot_builder::{encode_script_hex, generate_solvency_challenge_script};
+use actuarial_vm::{BisectionTrace, ClaimPrimitive, ExecCtx, Vm, VmError, OP_ASSERT_SOLVENCY};
+
+fn mock_claim(alpha_max_sats: u64) -> ClaimPrimitive {
+    ClaimPrimitive {
+        pi: [0u8; 32],
+        tau: [0u8; 32],
+        alpha_max_sats,
+        delta_blocks: 144,
+    }
+}
+
+#[test]
+fn fraudulent_trace_predicate_matches_fixture() {
+    let script = generate_solvency_challenge_script(100, 1_000).unwrap();
+    assert_eq!(encode_script_hex(&script), "01645a9502e8035f95a269");
+}
+
+#[test]
+fn vm_rejects_the_fraudulent_trace_scenario() {
+    let vm = Vm::new(100);
+    let err = vm
+        .execute(OP_ASSERT_SOLVENCY, &mock_claim(1_000), &ExecCtx::default())
+        .unwrap_err();
+    assert_eq!(err, VmError::SolvencyException);
+}
+
+#[test]
+fn trace_records_fail_closed_stack_after_for_the_fraud_case() {
+    let script = generate_solvency_challenge_script(100, 1_000).unwrap();
+    let mut trace = BisectionTrace::new();
+    trace.record_opcode(
+        OP_ASSERT_SOLVENCY,
+        vec!["100".to_string(), "1000".to_string()],
+        vec!["false".to_string()],
+        "0xabc1230000000000000000000000000000000000000000000000000000000000".to_string(),
+        encode_script_hex(&script),
+    );
+
+    let json = trace.to_json();
+    assert!(json.contains("\"stack_after\": [\"false\"]"));
+    assert!(json.contains("\"l1_predicate\": \"01645a9502e8035f95a269\""));
+}


### PR DESCRIPTION
## Summary
- add a regression test that proves the published fraud scenario fails closed in the VM
- add a deterministic fixture check for the published Taproot predicate bytes
- add FRAUD_PROOF.md documenting the witness vector and stack walk for the bounty scenario

## Testing
- cargo test

Fixes #1